### PR TITLE
Add sitemap regeneration after SEO population

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -1127,7 +1127,7 @@ class AutomatedTaskManager:
 
   <!-- Individual Event Pages -->'''
         
-        for event in events[:100]:  # Limit to avoid huge sitemaps
+        for event in events:
             # Get dynamic lastmod date from event
             event_lastmod = current_date
             if event.get('updated_at'):
@@ -1624,6 +1624,18 @@ class AutomatedTaskManager:
                     loop.run_until_complete(self.sync_with_ai_tools())
                 except Exception as e:
                     logger.error(f"Error in AI sync wrapper: {str(e)}")
+
+            def run_seo_population():
+                """Populate missing SEO fields on a schedule"""
+                try:
+                    from populate_production_seo_fields import populate_seo_data
+                    populate_seo_data()
+                    logger.info("✅ Scheduled SEO population completed")
+
+                    # Regenerate sitemap after SEO fields updated
+                    run_sitemap_generation()
+                except Exception as e:
+                    logger.error(f"Scheduled SEO population failed: {e}")
             
             # Sitemap generation - every 6 hours
             self.scheduler.add_job(
@@ -1667,6 +1679,15 @@ class AutomatedTaskManager:
                 trigger=IntervalTrigger(hours=6, start_date=datetime.utcnow() + timedelta(hours=3)),
                 id='event_cleanup',
                 name='Event Cleanup (32-day Archive)',
+                replace_existing=True
+            )
+
+            # SEO field population - every 24 hours (offset by 5 hours)
+            self.scheduler.add_job(
+                func=run_seo_population,
+                trigger=IntervalTrigger(hours=24, start_date=datetime.utcnow() + timedelta(hours=5)),
+                id='seo_population',
+                name='SEO Field Population',
                 replace_existing=True
             )
             

--- a/backend/seo_utils.py
+++ b/backend/seo_utils.py
@@ -244,6 +244,25 @@ def generate_event_json_ld(event: Dict[str, Any], base_url: str = "https://todo-
     
     return json_ld
 
+def generate_webpage_json_ld(event: Dict[str, Any], base_url: str = "https://todo-events.com") -> Dict[str, Any]:
+    """Generate WebPage JSON-LD for the event page"""
+    canonical = generate_canonical_url(
+        base_url,
+        event.get('slug', ''),
+        event.get('city', ''),
+        event.get('state', '')
+    )
+
+    description = event.get('short_description') or generate_short_description(event.get('description', ''))
+
+    return {
+        "@context": "https://schema.org",
+        "@type": "WebPage",
+        "name": event.get('title', ''),
+        "url": canonical,
+        "description": description,
+    }
+
 def generate_breadcrumb_json_ld(
     event: Dict[str, Any], 
     base_url: str = "https://todo-events.com"
@@ -460,7 +479,8 @@ class SEOEventProcessor:
             "metadata": generate_seo_metadata(processed_event, self.base_url),
             "json_ld": {
                 "event": generate_event_json_ld(processed_event, self.base_url),
-                "breadcrumb": generate_breadcrumb_json_ld(processed_event, self.base_url)
+                "breadcrumb": generate_breadcrumb_json_ld(processed_event, self.base_url),
+                "webpage": generate_webpage_json_ld(processed_event, self.base_url)
             },
             "validation_issues": validate_event_data(processed_event)
-        } 
+        }


### PR DESCRIPTION
## Summary
- generate sitemap entries for all events
- regenerate sitemap after the daily SEO population job runs

## Testing
- `pytest -q` *(fails: SystemExit due to missing DATABASE_URL)*

------
https://chatgpt.com/codex/tasks/task_e_6859498f4a18833093db3e06222a22f3