### PR TITLE
Update SEO population job

### DIFF
--- a/SEO_IMPROVEMENTS.md
+++ b/SEO_IMPROVEMENTS.md
@@ -28,12 +28,12 @@ The following Schema.org fields were missing or incomplete in our event pages:
 
 - Enhanced `generate_event_json_ld()` in `seo_utils.py` to include all required fields
 - Updated validation logic in `validate_event_data()` to check for missing fields
-- Created `fix_seo_fields.py` script to update existing events in the database
-- Added the script to deployment process to ensure all events have proper SEO fields
+- Introduced `populate_production_seo_fields.py` and a scheduled job `run_seo_population` as the single entry point for populating SEO fields
+- Removed the `fix_seo_fields.py` startup step; SEO data is populated only through the scheduled job
 
 ### Database Updates
 
-The script `fix_seo_fields.py` makes the following updates to events:
+The script `populate_production_seo_fields.py` performs the following updates to events:
 
 1. Adds missing organizer URLs
 2. Calculates end times for events missing them (defaults to 2 hours after start time)
@@ -42,16 +42,10 @@ The script `fix_seo_fields.py` makes the following updates to events:
 
 ### Testing
 
-You can run the script in dry-run mode to check for issues without making changes:
+The scheduled job handles SEO population automatically. To trigger it manually run:
 
 ```bash
-python backend/fix_seo_fields.py --dry-run
-```
-
-Or run it to fix the issues:
-
-```bash
-python backend/fix_seo_fields.py
+python backend/populate_production_seo_fields.py
 ```
 
 ### Future Improvements

--- a/backend/render.yaml
+++ b/backend/render.yaml
@@ -5,7 +5,6 @@ services:
     buildCommand: pip install -r requirements.txt
     startCommand: |
       python -m pip install -r requirements.txt
-      python fix_seo_fields.py
       uvicorn backend:app --host 0.0.0.0 --port $PORT --workers 1 --timeout-keep-alive 120
     envVars:
       - key: PYTHON_VERSION


### PR DESCRIPTION
## Summary
- remove the obsolete `fix_seo_fields.py` step from the backend render config
- document the new single SEO population entry point triggered by `run_seo_population`

## Testing
- `pip install -r backend/requirements.txt`
- `python -m pytest` *(fails: SystemExit and missing environment vars)*

------
https://chatgpt.com/codex/tasks/task_e_68643c0420c88330ac76ad41516e8a3d